### PR TITLE
Dashboard básico: lucro bruto (COGS real) + crescimento MoM + ajustes API/UI

### DIFF
--- a/infra/migrations/1759200000000_add_cogs_columns_pedido_itens.js
+++ b/infra/migrations/1759200000000_add_cogs_columns_pedido_itens.js
@@ -1,0 +1,27 @@
+/* eslint-disable camelcase */
+/**
+ * Migration: add COGS columns to pedido_itens
+ * - custo_unit_venda: custo unitário aplicado ao item no momento da venda (numeric)
+ * - custo_total_item: custo total = custo_unit_venda * quantidade (numeric)
+ */
+
+exports.shorthands = undefined;
+
+exports.up = (pgm) => {
+  pgm.addColumn("pedido_itens", {
+    custo_unit_venda: { type: "numeric(14,2)" },
+    custo_total_item: { type: "numeric(14,2)" },
+  });
+  pgm.createIndex("pedido_itens", ["pedido_id"], {
+    name: "pedido_itens_cogs_pedido_idx",
+  });
+};
+
+exports.down = (pgm) => {
+  pgm.dropIndex("pedido_itens", ["pedido_id"], {
+    name: "pedido_itens_cogs_pedido_idx",
+    ifExists: true,
+  });
+  pgm.dropColumn("pedido_itens", "custo_total_item", { ifExists: true });
+  pgm.dropColumn("pedido_itens", "custo_unit_venda", { ifExists: true });
+};

--- a/pages/api/v1/pedidos/[id].js
+++ b/pages/api/v1/pedidos/[id].js
@@ -183,10 +183,39 @@ async function putPedido(req, res) {
         totalBruto += preco * qtd;
         descontoTotal += desconto * qtd;
         totalLiquido += totalItem;
+        // custo unitário para VENDA no PUT: média das ENTRADAS até a data_emissao atual do pedido
+        let custoUnitVenda = null;
+        if (tipoAtual === "VENDA") {
+          const headDate = await client.query({
+            text: `SELECT data_emissao FROM pedidos WHERE id = $1`,
+            values: [id],
+          });
+          const dataEmissao = headDate.rows?.[0]?.data_emissao || null;
+          const custoQ = await client.query({
+            text: `SELECT COALESCE(SUM(valor_total)/NULLIF(SUM(quantidade),0),0) AS custo
+                   FROM movimento_estoque
+                   WHERE produto_id = $1 AND tipo = 'ENTRADA' AND data_movimento <= COALESCE($2::timestamptz, NOW())`,
+            values: [it.produto_id, dataEmissao],
+          });
+          custoUnitVenda = Number(custoQ.rows?.[0]?.custo ?? 0);
+        }
+        const custoTotalItem =
+          tipoAtual === "VENDA" && Number.isFinite(custoUnitVenda)
+            ? Number((custoUnitVenda * qtd).toFixed(2))
+            : null;
         await client.query({
-          text: `INSERT INTO pedido_itens (pedido_id, produto_id, quantidade, preco_unitario, desconto_unitario, total_item)
-       VALUES ($1,$2,$3,$4,$5,$6)`,
-          values: [id, it.produto_id, qtd, preco, desconto, totalItem],
+          text: `INSERT INTO pedido_itens (pedido_id, produto_id, quantidade, preco_unitario, desconto_unitario, total_item, custo_unit_venda, custo_total_item)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8)`,
+          values: [
+            id,
+            it.produto_id,
+            qtd,
+            preco,
+            desconto,
+            totalItem,
+            custoUnitVenda != null ? Number(custoUnitVenda.toFixed(2)) : null,
+            custoTotalItem,
+          ],
         });
 
         // guardar base para rateio de frete depois

--- a/tests/api/v1/pedidos/summary-crescimento.test.js
+++ b/tests/api/v1/pedidos/summary-crescimento.test.js
@@ -1,0 +1,151 @@
+/**
+ * @jest-environment node
+ */
+import orchestrator from "tests/orchestrator.js";
+import database from "infra/database.js";
+
+jest.setTimeout(60000);
+
+function randomDigits(len) {
+  let s = "";
+  for (let i = 0; i < len; i++) s += Math.floor(Math.random() * 10);
+  return s;
+}
+
+function ymd(d) {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+function yyyyMM(d) {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  return `${y}-${m}`;
+}
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  // Reset schema for isolation
+  await database.query("DROP SCHEMA public CASCADE; CREATE SCHEMA public;");
+  const mig = await fetch("http://localhost:3000/api/v1/migrations", {
+    method: "POST",
+  });
+  if (![200, 201].includes(mig.status)) {
+    throw new Error(`Falha ao aplicar migrações. Status: ${mig.status}`);
+  }
+});
+
+async function criaPF(nome = "Cliente MoM") {
+  const resp = await fetch("http://localhost:3000/api/v1/entities", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      name: nome,
+      entity_type: "PF",
+      document_digits: randomDigits(11),
+      ativo: true,
+    }),
+  });
+  expect([200, 201]).toContain(resp.status);
+  return await resp.json();
+}
+
+async function criaPJ(nome = "Fornecedor MoM") {
+  const resp = await fetch("http://localhost:3000/api/v1/entities", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name: nome, entity_type: "PJ" }),
+  });
+  expect([200, 201]).toContain(resp.status);
+  return await resp.json();
+}
+
+async function criaProduto(nome = "Prod MoM", preco = 100) {
+  const forn = await criaPJ("FORN MoM");
+  const resp = await fetch("http://localhost:3000/api/v1/produtos", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      nome,
+      preco_tabela: preco,
+      ativo: true,
+      fornecedor_id: forn.id,
+    }),
+  });
+  expect([200, 201]).toContain(resp.status);
+  return await resp.json();
+}
+
+describe("Summary Crescimento MoM", () => {
+  test("Calcula crescimento vs mês anterior", async () => {
+    const cliente = await criaPF();
+    const prod = await criaProduto();
+
+    const now = new Date();
+    const curMonth = yyyyMM(now);
+    const prev = new Date(now.getFullYear(), now.getMonth() - 1, 10);
+    const prevMonth = yyyyMM(prev);
+
+    // Garantir estoque para as vendas
+    const entrada = await fetch(
+      "http://localhost:3000/api/v1/estoque/movimentos",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          produto_id: prod.id,
+          tipo: "ENTRADA",
+          quantidade: 10,
+          valor_unitario: 50,
+        }),
+      },
+    );
+    expect([200, 201]).toContain(entrada.status);
+
+    // Uma venda no mês anterior: 200
+    const vendaPrev = await fetch("http://localhost:3000/api/v1/pedidos", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        tipo: "VENDA",
+        partner_entity_id: cliente.id,
+        partner_name: cliente.name,
+        data_emissao: ymd(prev),
+        itens: [{ produto_id: prod.id, quantidade: 1, preco_unitario: 200 }],
+      }),
+    });
+    expect([200, 201]).toContain(vendaPrev.status);
+
+    // Duas vendas no mês atual: 300
+    const vendaCur = await fetch("http://localhost:3000/api/v1/pedidos", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        tipo: "VENDA",
+        partner_entity_id: cliente.id,
+        partner_name: cliente.name,
+        itens: [{ produto_id: prod.id, quantidade: 1, preco_unitario: 300 }],
+      }),
+    });
+    expect([200, 201]).toContain(vendaCur.status);
+
+    const sumPrev = await fetch(
+      `http://localhost:3000/api/v1/pedidos/summary?month=${prevMonth}`,
+    );
+    expect(sumPrev.status).toBe(200);
+    const jsPrev = await sumPrev.json();
+    expect(Number(jsPrev.vendasMes)).toBe(200);
+
+    const sumCur = await fetch(
+      `http://localhost:3000/api/v1/pedidos/summary?month=${curMonth}`,
+    );
+    expect(sumCur.status).toBe(200);
+    const jsCur = await sumCur.json();
+    expect(Number(jsCur.vendasMesAnterior)).toBe(200);
+    expect(Number(jsCur.vendasMes)).toBe(300);
+    // Crescimento: (300-200)/200 = 50%
+    expect(Number(jsCur.crescimentoMoMPerc)).toBe(50);
+  });
+});

--- a/tests/api/v1/pedidos/summary-lucro.test.js
+++ b/tests/api/v1/pedidos/summary-lucro.test.js
@@ -1,0 +1,136 @@
+/**
+ * @jest-environment node
+ */
+// tests/api/v1/pedidos/summary-lucro.test.js
+import orchestrator from "tests/orchestrator.js";
+import database from "infra/database.js";
+
+jest.setTimeout(60000);
+
+function randomDigits(len) {
+  let s = "";
+  for (let i = 0; i < len; i++) s += Math.floor(Math.random() * 10);
+  return s;
+}
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  // Reset schema for isolation
+  await database.query("DROP SCHEMA public CASCADE; CREATE SCHEMA public;");
+  const mig = await fetch("http://localhost:3000/api/v1/migrations", {
+    method: "POST",
+  });
+  if (![200, 201].includes(mig.status)) {
+    throw new Error(`Falha ao aplicar migrações. Status: ${mig.status}`);
+  }
+});
+
+async function criaParceiroPF(nome = "Cliente PF Teste") {
+  const resp = await fetch("http://localhost:3000/api/v1/entities", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      name: nome,
+      entity_type: "PF",
+      document_digits: randomDigits(11),
+      document_pending: false,
+      ativo: true,
+    }),
+  });
+  expect([200, 201]).toContain(resp.status);
+  return await resp.json();
+}
+
+async function criaParceiroPJ(nome = "Fornecedor Teste") {
+  const resp = await fetch("http://localhost:3000/api/v1/entities", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name: nome, entity_type: "PJ" }),
+  });
+  expect([200, 201]).toContain(resp.status);
+  return await resp.json();
+}
+
+async function criaProduto(nome = "Produto Teste", preco = 20) {
+  const forn = await criaParceiroPJ("FORN LUCRO");
+  const resp = await fetch("http://localhost:3000/api/v1/produtos", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      nome,
+      preco_tabela: preco,
+      ativo: true,
+      fornecedor_id: forn.id,
+    }),
+  });
+  expect([200, 201]).toContain(resp.status);
+  return await resp.json();
+}
+
+function yyyyMM(d = new Date()) {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  return `${y}-${m}`;
+}
+
+describe("Resumo com COGS real (pedido_itens.custo_total_item)", () => {
+  test("Apura COGS real no mês e calcula lucro/margem", async () => {
+    const cliente = await criaParceiroPF();
+    const prod = await criaProduto("Racao", 20);
+
+    // Entrada: custo 10, quantidade 5
+    const entrada = await fetch(
+      "http://localhost:3000/api/v1/estoque/movimentos",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          produto_id: prod.id,
+          tipo: "ENTRADA",
+          quantidade: 5,
+          valor_unitario: 10,
+        }),
+      },
+    );
+    expect([200, 201]).toContain(entrada.status);
+
+    // Venda: preço 20, quantidade 3 => receita 60; COGS real 3*10 = 30; lucro 30; margem 50%
+    const venda = await fetch("http://localhost:3000/api/v1/pedidos", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        tipo: "VENDA",
+        partner_entity_id: cliente.id,
+        partner_name: cliente.name,
+        itens: [{ produto_id: prod.id, quantidade: 3, preco_unitario: 20 }],
+      }),
+    });
+    expect([200, 201]).toContain(venda.status);
+    const pedido = await venda.json();
+
+    // Verifica que item gravou custo
+    const getPedido = await fetch(
+      `http://localhost:3000/api/v1/pedidos/${pedido.id}`,
+    );
+    const pedBody = await getPedido.json();
+    expect(Array.isArray(pedBody.itens)).toBe(true);
+    expect(Number(pedBody.itens[0].custo_unit_venda)).toBe(10);
+    expect(Number(pedBody.itens[0].custo_total_item)).toBe(30);
+
+    // Summary do mês corrente
+    const month = yyyyMM(new Date());
+    const sum = await fetch(
+      `http://localhost:3000/api/v1/pedidos/summary?month=${month}`,
+    );
+    expect(sum.status).toBe(200);
+    const json = await sum.json();
+    expect(json).toHaveProperty("vendasMes");
+    expect(json).toHaveProperty("cogsReal");
+    expect(json).toHaveProperty("lucroBrutoMes");
+    expect(json).toHaveProperty("margemBrutaPerc");
+    expect(Number(json.vendasMes)).toBe(60);
+    expect(Number(json.cogsReal)).toBe(30);
+    expect(Number(json.lucroBrutoMes)).toBe(30);
+    expect(Number(json.margemBrutaPerc)).toBe(50);
+  });
+});


### PR DESCRIPTION
## Resumo
Este PR entrega o dashboard básico acima da lista de pedidos, com métricas mensais e modais de detalhes, adiciona o cálculo preciso de lucro bruto (utilizando COGS real por item de venda) e um novo card de Crescimento (MoM). Também inclui endpoints e testes relacionados.

## Principais mudanças
- UI (OrdersDashboard):
  - Cards: Vendas do mês, Compras do mês, Lucro Bruto (preciso), Promissórias (pagas/pendentes/atrasadas), Próximo mês, Carry-over e novo card de Crescimento (MoM).
  - Seletor de mês (input type="month").
  - Cada card abre um modal com listas/detalhes e explicações (sem travar o fluxo da tela principal).
- API:
  - `GET /api/v1/pedidos/summary`:
    - Usa COGS real: soma de `pedido_itens.custo_total_item` em vendas do mês.
    - Retorna: `vendasMes`, `comprasMes`, `cogsReal`, `lucroBrutoMes`, `margemBrutaPerc`.
    - Novo: `vendasMesAnterior` e `crescimentoMoMPerc` (mês vs. anterior).
  - `POST /api/v1/pedidos` e `PUT /api/v1/pedidos/:id` (VENDA):
    - Persistem `custo_unit_venda` e `custo_total_item` no momento da emissão, usando custo médio das ENTRADAS até `data_emissao`.
- Banco de dados:
  - Colunas novas em `pedido_itens`: `custo_unit_venda numeric(14,2)`, `custo_total_item numeric(14,2)`.
  - Índice em `pedido_id` para consultas de COGS no summary.

## Testes
- `tests/api/v1/pedidos/summary-lucro.test.js`: valida COGS real e lucro/margem mensal (ex.: receita 60, COGS 30, lucro 30, margem 50%).
- `tests/api/v1/pedidos/summary-crescimento.test.js`: cria vendas em mês anterior e atual e valida `vendasMesAnterior` e `crescimentoMoMPerc` (ex.: 50%).
- Suíte de migrações e status permanece verde.

## Como validar
1. Aplicar migrações (se necessário): `POST /api/v1/migrations` (ou via scripts).
2. Rodar em dev: `npm run dev`.
3. Abrir / (lista de pedidos) e verificar o dashboard no topo.
4. Alternar o mês e observar atualização dos cards.
5. Clicar nos cards para abrir modais e conferir listas/valores.

## Considerações
- O campo antigo de COGS estimado (se existia) foi substituído por `cogsReal`; o frontend foi atualizado para refletir.
- Política atual no PUT: recalcula custo do item com base na `data_emissao` vigente. Podemos “congelar custo” em edições, se preferível, num PR futuro.

## Checklist
- [x] Migrações aplicadas
- [x] Endpoints atualizados e idempotentes
- [x] UI com card de Crescimento (MoM) e modais
- [x] Testes de API adicionados e passando
- [x] Documentação inline/explicações nos modais

## Próximos passos (opcional)
- YoY (mês vs. mesmo mês do ano anterior)
- Margem após frete e Frete %
- Top produtos/clients do mês por receita/margem
- Estratégia de “custo congelado” em PUT de VENDA